### PR TITLE
fix: clear superscript

### DIFF
--- a/packages/marks/basic-marks/src/createSubscriptPlugin.ts
+++ b/packages/marks/basic-marks/src/createSubscriptPlugin.ts
@@ -17,7 +17,7 @@ export const createSubscriptPlugin = createPluginFactory<ToggleMarkPlugin>({
   },
   options: {
     hotkey: 'mod+.',
-    clear: MARK_SUBSCRIPT,
+    clear: MARK_SUPERSCRIPT,
   },
   deserializeHtml: [
     { validNodeName: ['SUB'] },


### PR DESCRIPTION
The plugin would clear MARK_SUBSCRIPT instead of MARK_SUPERSCRIPT which wouldn't be super apparent since it then would set MARK_SUBSCRIPT giving you the desired results but can lead to the case where both marks are set at once.

**Description**



<!-- A clear and concise description of what this pull request solves. -->
<!-- If your change is non-trivial, please include a description of how the
new logic works, and why you decided to solve it the way you did. -->

**Issue**

Fixes: 

**Example**



<!-- (optional) A sandbox, GIF or video showing the old and new behaviors after this
pullrequest is merged. Or a code sample showing the usage of a new API. -->

## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn lint
      --fix`.)
- [x] The relevant examples still work: (Run examples with `yarn docs`.)

<!--

If your answer is yes to any of these, please make sure to include it in
your PR.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
